### PR TITLE
Support for nested pipes/handlers retuned by a pipe point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ log
 project.sublime-workspace
 test/static
 coverage/*
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ examples
 .cache
 .git
 .github
+yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## Next version
+* Added pipe.store to store properties specific to the given pipe point. This is useful to share things between different requests. One can store there objects that needs to be initialized only once. 
 * Added support for nested pipes/handlers that can be retuned by some pipe handlers instead of hooking to the main flow.
 
 ## v2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # ChangeLog
 
 ## Next version
+* Added support for nested pipes that can be retuned by some pipe handlers instead of hooking to the main flow.
 
 ## v2.0.2
 * Branding changes
 
 ## v2.0.1
 * Disabled resuming on stream.write call to avoid conflicts that may arise from auto-resume in bi-directional stream.
-* Refined the logic related to what happens with the message when the pipe point is resumed. 
+* Refined the logic related to what happens with the message when the pipe point is resumed.
 * Added examples of request and response streaming.
 
 ## v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 ## Next version
-* Added support for nested pipes that can be retuned by some pipe handlers instead of hooking to the main flow.
+* Added support for nested pipes/handlers that can be retuned by some pipe handlers instead of hooking to the main flow.
 
 ## v2.0.2
 * Branding changes

--- a/README.md
+++ b/README.md
@@ -216,12 +216,24 @@ The pipe object is passed to all handlers and transport during initialization wh
 * **`create`**`([context], [customApiImpl])` - creates a pipeline with new context or clones from the existing one if any present. The method is mandatory to initiate a new flow, otherwise the subsequent call will fail.
      * **`context`** is a context object to be used in request/message flow.
      * **`customApiImpl`** is a name for a specific API implementation. It allows to inject custom API provided by one of the handlers that needs to be returned instead of the generic pipe interface.
-* **`context`** - is an object available to all handlers/transport in the same request/response flow. One can use it to store data that needs to be shared between handlers if needed. The values in the context that have their names started with '$' will not be propagated beyond the pipe boundaries. To access context one can use pipe.context;
-* **`link`**`(pipe)` - links passed pipeline to the current one. The link between pipes exists as long as the context where they were linked exists. Once pipe.create is used, it will lose the link. The linking can be useful to join pipes on the fly, for example to bootstrap pipe from config file and inline it into existing pipeline where bootstrap handler is registered.
+* **`context`** is an object available to all handlers/transport in the same request/response flow. One can use it to store data that needs to be shared between handlers if needed. The values in the context that have their names started with '$' will not be propagated beyond the pipe boundaries. To access context one can use pipe.context;
+* **`store`** is a storage for properties specific to the given pipe point. This is useful to share things between different requests. One can store there objects that needs to be initialized only once.
+```js
+Trooba.use(function (pipe, config) {
+    if (!pipe.store.obj) {
+        // do it only once
+        pipe.store.obj = createSomething(config);
+    }
+    pipe.on('request', function (request) {
+        pipe.respond(pipe.store.obj);
+    });
+});
+```
+* **`link`**`(pipe)` links passed pipeline to the current one. The link between pipes exists as long as the context where they were linked exists. Once pipe.create is used, it will lose the link. The linking can be useful to join pipes on the fly, for example to bootstrap pipe from config file and inline it into existing pipeline where bootstrap handler is registered.
 ```js
 Trooba.use(function bootstrapPipe(pipe) {
     // load all the handlers from some json or config file
-    var handlers = []; // assume it is loaded as an array
+    var handlers = ['handler-1', 'handler-2', ...]; // assume it is loaded as an array
     // build the pipe or load from cache
     var bootstrappedPipe = handlers.reduce((trooba, handler) => {
         return trooba.use(handler);

--- a/index.js
+++ b/index.js
@@ -402,6 +402,10 @@ PipePoint.prototype = {
                 // if pipe is returned, let's attach it to the existing one
                 current.link(ret);
             }
+            else if (ret) {
+                current.handler = ret;
+                current.handler(current, current.config);
+            }
             current = current._next$ ?
                 current._next$.copy(context) : undefined;
         }

--- a/index.js
+++ b/index.js
@@ -397,7 +397,11 @@ PipePoint.prototype = {
 
         var current = head;
         while(current) {
-            current.handler(current, current.config);
+            var ret = current.handler(current, current.config);
+            if (ret instanceof PipePoint) {
+                // if pipe is returned, let's attach it to the existing one
+                current.link(ret);
+            }
             current = current._next$ ?
                 current._next$.copy(context) : undefined;
         }

--- a/index.js
+++ b/index.js
@@ -119,6 +119,7 @@ function PipePoint(handler) {
     PipePoint.instanceCounter = PipePoint.instanceCounter ? PipePoint.instanceCounter : 0;
     this._uid = PipePoint.instanceCounter++;
     this._id = (this.handler ? this.handler.name + '-' : '') + this._uid;
+    this.store = {};
 }
 
 module.exports.PipePoint = PipePoint;
@@ -186,6 +187,7 @@ PipePoint.prototype = {
         ret._messageHandlers = this._messageHandlers;
         ret.config = this.config;
         ret.handler = this.handler;
+        ret.store = this.store;
         ret.context = context;
         ret._pointCtx();
         return ret;

--- a/test/index.js
+++ b/test/index.js
@@ -318,6 +318,26 @@ describe(__filename, function () {
         });
     });
 
+    it('should preserve properties in pipe.store', function (done) {
+        var pipe = Trooba
+        .use(function (pipe) {
+            pipe.on('request', function (request) {
+                if (request === 'get') {
+                    return pipe.respond(pipe.store.request);
+                }
+                pipe.store.request = request;
+            });
+        })
+        .build();
+
+        pipe.create().request('foo', function () {});
+        pipe.create().request('get', function (err, response) {
+            Assert.ok(!err);
+            Assert.equal('foo', response);
+            done();
+        });
+    });
+
     it('should execute a chain', function (done) {
         Trooba
         .use(function handler(pipe) {


### PR DESCRIPTION
This allows to link implicitly the pipe to the pipes or single handlers returned by a pipe point.

## Motivation and Context
This changes is needed by trooba-router or similar modules that may return extension to the main pipe.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
