### PR TITLE
fix: improve compatibility with webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,9 @@
 
 var TTL = Infinity;
 
-var defer = process && process.nextTick && process.nextTick.bind(process) ||
-    setImmediate || function defer(fn) {
-        setTimeout(fn, 0); // this is much slower then setImmediate or nextTick
-    };
+var defer = function defer(fn) {
+    Promise.resolve().then(fn);
+}
 
 function createPipeConnector(to) {
     return function pipeConnect(pipe) {
@@ -23,7 +22,7 @@ function Trooba() {
 Trooba.prototype = {
 
     use: function (handler, config) {
-        if (typeof handler === 'string') {
+        if (typeof handler === 'string' && typeof window === 'undefined') {
             handler = require(handler);
         }
 


### PR DESCRIPTION
## Description
Fixes two issues that occur when loading this module within webpack.

1. This module checks for `process` an `setImmediate` which are node only apis that are no longer shimmed by default in webpack 5. I changed the `defer` code to instead use promise timing which is essentially the same as `process.nextTick` and works in server and browser.

2. This module has a dynamic require which will log a warning in webpack. I updated this to first check if we are bundling for the browser via a `typeof window` check to avoid the warning.

## Motivation and Context
Should work out of the box with webpack.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
